### PR TITLE
fixes issue where message is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,6 +157,7 @@ class Logger {
   output() {
     if (
       !canLog(this.response.severity)
+      || isEmpty(this.response.message)
       || this.response.message.match(EXCLUDE_MESSAGE_FROM_LOG_PATTERN)
     ) {
       this.response = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kudosinc/node_logger",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kudosinc/node_logger",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A logger for node services",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"


### PR DESCRIPTION
I couldn't find a case where the message could be empty, but in either case the node logger should not throw exceptions in case of empty message, and since the message is empty, the logs should not printed. Adding an `isEmpty` condition to the message should not throw the exception